### PR TITLE
Update nix run command to use `icehouse` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 You can try Ice House without committing to installing it on your system by running the following command.
 
 ```bash
-nix run github:snowfallorg/icehouse
+nix run github:snowfallorg/icehouse#icehouse
 ```
 
 ## Install Ice House


### PR DESCRIPTION
When running the command from the readme to try without installing, I get an error:
```
✦ ❯ nix run github:snowfallorg/icehouse
error: flake 'github:snowfallorg/icehouse' does not provide attribute 'apps.x86_64-linux.default', 'defaultApp.x86_64-linux', 'packages.x86_64-linux.default' or 'defaultPackage.x86_64-linux'
```
It seems like I needed to add `#icehouse` to the end.

Alternatively, instead of this PR maybe a default output could be added?